### PR TITLE
[Windows] Added Batch file equivalent of wasm_pack_cmd 

### DIFF
--- a/wasm-builder.js
+++ b/wasm-builder.js
@@ -33,7 +33,11 @@ chokidar.watch(['./crate/src', './crate/Cargo.toml']).on('change', async (event,
 });
 
 bundler.on('buildStart', () => {
-    const prevtBuildFile = Path.join(__dirname, './wasm_pack_cmd');
+    let prevtBuildFile = Path.join(__dirname, './wasm_pack_cmd');
+    if(process.platform == "win32") {
+        prevtBuildFile = Path.join(__dirname, './wasm_pack_cmd.bat');
+    }
+
     console.log(`running: ${prevtBuildFile}`);
     execSync(`${prevtBuildFile} ${buildType === 'production' ? '' : '--dev'}`, {stdio: 'inherit'});
 });

--- a/wasm_pack_cmd.bat
+++ b/wasm_pack_cmd.bat
@@ -1,0 +1,1 @@
+wasm-pack build crate --target web 


### PR DESCRIPTION
I added a Batch file that will be used instead of wasm_pack_cmd when node is run on windows.
I dont know if this breaks anything, but i think it'll be alright for now.

